### PR TITLE
Fix bug "Internal error: unable to find the outer accessor symbol of class"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,15 +10,21 @@ lazy val commonSettings = Seq(
 
 lazy val core = (project in file("core")).dependsOn(macros, comun)
 	.settings(
-		commonSettings
+		commonSettings,
 		// other settings
+    scalacOptions ++= Seq(
+      "-language:experimental.macros"
+    )
 	)
 
 lazy val macros = (project in file("macros")).dependsOn(comun)
 	.settings(
-		commonSettings
+		commonSettings,
 		// other settings
-  	)
+    scalacOptions ++= Seq(
+      "-language:experimental.macros"
+    )
+  )
 
 lazy val comun = (project in file("comun"))
 

--- a/macros/src/main/scala/jsfacile/macros/CoproductAppenderHelper.scala
+++ b/macros/src/main/scala/jsfacile/macros/CoproductAppenderHelper.scala
@@ -301,7 +301,8 @@ if (proxy.isEmpty) {
 
 				ctx.info(ctx.enclosingPosition, s"coproduct appender helper unchecked init for ${show(coproductType)} : ${show(caHelperInitCodeLines)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false);
 				// the recursion is triggered by the type-check
-				coproductHandler.oExpression = Some(ctx.Expr[Unit](ctx.typecheck(caHelperInitCodeLines)));
+        ctx.typecheck(caHelperInitCodeLines.duplicate)
+				coproductHandler.oExpression = Some(ctx.Expr[Unit](caHelperInitCodeLines))
 				coproductHandler.isCapturingDependencies = false
 				ctx.info(ctx.enclosingPosition, s"coproduct appender helper after init check for ${show(coproductType)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false);
 
@@ -345,11 +346,9 @@ import _root_.jsfacile.macros.CoproductAppenderHelper.caHelpersBuffer;
 caHelpersBuffer(${coproductHandler.typeIndex}).get[$coproductType]"""
 			}
 
-		ctx.info(ctx.enclosingPosition, s"coproduct appender helper unchecked body for ${show(coproductType)}: ${show(body)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false);
-		val checkedBody = ctx.typecheck(body);
-		ctx.info(ctx.enclosingPosition, s"coproduct appender helper after body check for ${show(coproductType)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false);
+		ctx.info(ctx.enclosingPosition, s"coproduct appender helper unchecked body for ${show(coproductType)}: ${show(body)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false)
 
-		ctx.Expr[CoproductAppenderHelper[C]](checkedBody);
+		ctx.Expr[CoproductAppenderHelper[C]](body);
 	}
 }
 

--- a/macros/src/main/scala/jsfacile/macros/CoproductParserHelper.scala
+++ b/macros/src/main/scala/jsfacile/macros/CoproductParserHelper.scala
@@ -216,7 +216,8 @@ if (proxy.isEmpty) {
 
 				ctx.echo(ctx.enclosingPosition, s"coproduct parser helper unchecked init for ${show(coproductType)} : ${show(cpHelperInitCodeLines)}\n------\nhandlers:$showParserHandlers\n${showOpenImplicitsAndMacros(ctx)}");
 				// the recursion is triggered by the type-check
-				coproductHandler.oExpression = Some(ctx.Expr[Unit](ctx.typecheck(cpHelperInitCodeLines)));
+        ctx.typecheck(cpHelperInitCodeLines.duplicate)
+				coproductHandler.oExpression = Some(ctx.Expr[Unit](cpHelperInitCodeLines))
 				coproductHandler.isCapturingDependencies = false
 				ctx.echo(ctx.enclosingPosition, s"coproduct appender helper after init check for ${show(coproductType)}\n------\nhandlers:$showParserHandlers\n${showOpenImplicitsAndMacros(ctx)}");
 
@@ -261,11 +262,9 @@ import _root_.jsfacile.macros.CoproductParserHelper;
 CoproductParserHelper.cpHelpersBuffer(${coproductHandler.typeIndex}).get[$coproductType]"""
 			}
 
-		ctx.echo(ctx.enclosingPosition, s"coproduct parser helper unchecked body for ${show(coproductType)}: ${show(body)}\n------\nhandlers:$showParserHandlers\n${showOpenImplicitsAndMacros(ctx)}");
-		val checkedBody = ctx.typecheck(body);
-		ctx.echo(ctx.enclosingPosition, s"coproduct parser helper after body check for ${show(coproductType)}\n------\nhandlers:$showParserHandlers\n${showOpenImplicitsAndMacros(ctx)}");
+		ctx.echo(ctx.enclosingPosition, s"coproduct parser helper unchecked body for ${show(coproductType)}: ${show(body)}\n------\nhandlers:$showParserHandlers\n${showOpenImplicitsAndMacros(ctx)}")
 
-		ctx.Expr[CoproductParserHelper[C]](checkedBody);
+		ctx.Expr[CoproductParserHelper[C]](body);
 	}
 }
 

--- a/macros/src/main/scala/jsfacile/macros/EnumParserMacro.scala
+++ b/macros/src/main/scala/jsfacile/macros/EnumParserMacro.scala
@@ -14,6 +14,6 @@ object EnumParserMacro {
 		val enumModuleSymbol = enumType.termSymbol.asModule;
 		val body = q"""new _root_.jsfacile.read.EnumParser[${enumModuleSymbol}](${enumModuleSymbol})""";
 
-		ctx.Expr[Parser[E#Value]](ctx.typecheck(body));
+		ctx.Expr[Parser[E#Value]](body)
 	}
 }

--- a/macros/src/main/scala/jsfacile/macros/ProductAppender.scala
+++ b/macros/src/main/scala/jsfacile/macros/ProductAppender.scala
@@ -129,7 +129,8 @@ if (proxy.isEmpty) {
 
 				ctx.info(ctx.enclosingPosition, s"product appender unchecked init for ${show(productType)} : ${show(productAppenderExpression)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false);
 				// the recursion is triggered by the type-check
-				productHandler.oExpression = Some(ctx.Expr[Unit](ctx.typecheck(productAppenderExpression)));
+        ctx.typecheck(productAppenderExpression)
+				productHandler.oExpression = Some(ctx.Expr[Unit](productAppenderExpression))
 				productHandler.isCapturingDependencies = false
 				ctx.info(ctx.enclosingPosition, s"product appender after init check for ${show(productType)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false);
 
@@ -174,9 +175,7 @@ productsAppendersBuffer(${productHandler.typeIndex}).get[$productType]"""
 			}
 
 		ctx.info(ctx.enclosingPosition, s"product appender unchecked body for ${show(productType)}: ${show(body)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false)
-		val checkedBody = ctx.typecheck(body);
-		ctx.info(ctx.enclosingPosition, s"product appender after body check for ${show(productType)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false)
 
-		ctx.Expr[Appender[P]](checkedBody);
+		ctx.Expr[Appender[P]](body)
 	}
 }

--- a/macros/src/main/scala/jsfacile/macros/ProductAppender.scala
+++ b/macros/src/main/scala/jsfacile/macros/ProductAppender.scala
@@ -129,7 +129,7 @@ if (proxy.isEmpty) {
 
 				ctx.info(ctx.enclosingPosition, s"product appender unchecked init for ${show(productType)} : ${show(productAppenderExpression)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false);
 				// the recursion is triggered by the type-check
-        ctx.typecheck(productAppenderExpression)
+        ctx.typecheck(productAppenderExpression.duplicate)
 				productHandler.oExpression = Some(ctx.Expr[Unit](productAppenderExpression))
 				productHandler.isCapturingDependencies = false
 				ctx.info(ctx.enclosingPosition, s"product appender after init check for ${show(productType)}\n------\nhandlers:$showAppenderHandlers\n${showOpenImplicitsAndMacros(ctx)}", force = false);

--- a/macros/src/main/scala/jsfacile/macros/ProductParserHelper.scala
+++ b/macros/src/main/scala/jsfacile/macros/ProductParserHelper.scala
@@ -146,7 +146,8 @@ if (proxy.isEmpty) {
 }""";
 				ctx.echo(ctx.enclosingPosition, s"product parser helper unchecked init for ${show(productType)}: ${show(ppHelperInitCodeLines)}\n------\nhandlers:$showParserHandlers\n${showOpenImplicitsAndMacros(ctx)}");
 				// the recursion is triggered by the type-check
-				productHandler.oExpression = Some(ctx.Expr[Unit](ctx.typecheck(ppHelperInitCodeLines)));
+        ctx.typecheck(ppHelperInitCodeLines.duplicate)
+				productHandler.oExpression = Some(ctx.Expr[Unit](ppHelperInitCodeLines))
 				productHandler.isCapturingDependencies = false
 				ctx.echo(ctx.enclosingPosition, s"product parser helper after init check for ${show(productType)}\n------\nhandlers:$showParserHandlers\n${showOpenImplicitsAndMacros(ctx)}");
 
@@ -193,11 +194,9 @@ import ProductParserHelper.ppHelpersBuffer;
 ppHelpersBuffer(${productHandler.typeIndex}).get[$productType]"""
 			}
 
-		ctx.echo(ctx.enclosingPosition, s"product parser helper unchecked body for ${show(productType)}: ${show(body)}\n------\nhandlers:$showParserHandlers\n${showOpenImplicitsAndMacros(ctx)}");
-		val checkedBody = ctx.typecheck(body);
-		ctx.echo(ctx.enclosingPosition, s"product parser helper after body check for ${show(productType)}\n------\nhandlers:$showParserHandlers\n${showOpenImplicitsAndMacros(ctx)}");
+		ctx.echo(ctx.enclosingPosition, s"product parser helper unchecked body for ${show(productType)}: ${show(body)}\n------\nhandlers:$showParserHandlers\n${showOpenImplicitsAndMacros(ctx)}")
 
-		ctx.Expr[ProductParserHelper[P]](checkedBody);
+		ctx.Expr[ProductParserHelper[P]](body)
 
 	}
 }

--- a/macros/src/main/scala/jsfacile/macros/SingletonParserHelper.scala
+++ b/macros/src/main/scala/jsfacile/macros/SingletonParserHelper.scala
@@ -29,7 +29,7 @@ new SingletonParserHelper[$singletonType] {
 }"""
 			// ctx.info(ctx.enclosingPosition, "sph helper: " + show(helper), false)
 
-			ctx.Expr[SingletonParserHelper[S]](ctx.typecheck(helper));
+			ctx.Expr[SingletonParserHelper[S]](helper)
 		} else {
 			ctx.abort(ctx.enclosingPosition, s"$singletonSymbol is not a module class")
 		}


### PR DESCRIPTION
See details: https://stackoverflow.com/questions/64950654/how-to-use-a-universe-tree-created-and-type-checked-in-one-scala-macro-executi